### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://claudfatec.visualstudio.com/a387e6ab-a343-4ae8-ae2a-bbf0264eef1f/587f3d27-c907-45f6-ab90-8642eff0b453/_apis/work/boardbadge/3037c3b6-af4e-4618-a56f-98bb27f2585c)](https://claudfatec.visualstudio.com/a387e6ab-a343-4ae8-ae2a-bbf0264eef1f/_boards/board/t/587f3d27-c907-45f6-ab90-8642eff0b453/Microsoft.RequirementCategory)
 # azuretest
 Repositório de testes com Azure.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://claudfatec.visualstudio.com/a387e6ab-a343-4ae8-ae2a-bbf0264eef1f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.